### PR TITLE
Fixing issue with create/update not working in ActiveAdmin

### DIFF
--- a/lib/questionable/admin/answers.rb
+++ b/lib/questionable/admin/answers.rb
@@ -15,5 +15,15 @@ if defined?(ActiveAdmin)
       column(:message)
       actions
     end
+
+    form as: :questionable_answer do |f|
+      f.inputs do
+        f.input :user
+        f.input :assignment
+        f.input :option
+        f.input :message
+      end
+      f.actions
+    end
   end
 end

--- a/lib/questionable/admin/assignment.rb
+++ b/lib/questionable/admin/assignment.rb
@@ -11,7 +11,7 @@ if defined?(ActiveAdmin)
       column :updated_at
     end
 
-    form do |f|
+    form as: :questionable_assignment do |f|
       f.inputs do
         f.input :question
         f.input :subject_type

--- a/lib/questionable/admin/option.rb
+++ b/lib/questionable/admin/option.rb
@@ -16,5 +16,15 @@ if defined?(ActiveAdmin)
         destroy!(location: admin_question_path(resource.question))
       end
     end
+
+    form as: :questionable_option do |f|
+      f.inputs do
+        f.input :question
+        f.input :title
+        f.input :note
+        f.input :position
+      end
+      f.actions
+    end
   end
 end

--- a/lib/questionable/admin/question.rb
+++ b/lib/questionable/admin/question.rb
@@ -8,7 +8,7 @@ if defined?(ActiveAdmin)
     filter :category
     filter :input_type
 
-    form do |f|
+    form as: :questionable_question do |f|
       f.inputs do
         f.input :title
         f.input :note


### PR DESCRIPTION
* Attempts to save always yielded "can't be blank" errors. This was
  caused by the wrong key being used in the request body
* See http://stackoverflow.com/questions/25395578/active-admin-namespaced-model-form