### PR TITLE
try to fix test on CircleCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :tests do
   gem 'autotest-rails'
   gem 'autotest-fsevent'  # Make autotest faster on OS X
   gem 'autotest-notification'  # show popup notices
+  gem 'test-unit'
 end
 
 
@@ -32,4 +33,3 @@ end
 
 # To use debugger
 # gem 'debugger'
-


### PR DESCRIPTION

```
/opt/circleci/ruby/ruby-2.2.4/bin/ruby -I/home/ubuntu/questionable/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.5.4/lib:/home/ubuntu/questionable/vendor/bundle/ruby/2.2.0/gems/rspec-support-3.5.0/lib /home/ubuntu/questionable/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/home/ubuntu/questionable/vendor/bundle/ruby/2.2.0/gems/activesupport-3.2.22.5/lib/active_support/dependencies.rb:251:in `require': Ruby 2.2+ has removed test/unit from the core library. Rails requires this as a dependency. Please add test-unit gem to your Gemfile: `gem 'test-unit', '~> 3.0'` (cannot load such file -- test/unit)" (LoadError)
```