### PR TITLE
Refactoring subject to not allow string/symbols

### DIFF
--- a/app/models/questionable/assignment.rb
+++ b/app/models/questionable/assignment.rb
@@ -13,9 +13,6 @@ module Questionable
 
     delegate :answers_for_user, to: :question
 
-    scope :with_subject, ->(subject) {
-      condition = subject.is_a?(Symbol) || subject.is_a?(String) ? { subject_type: subject } : { subject: subject }
-      where(condition).order(:position)
-    }
+    scope :with_subject, ->(subject) { where(subject: subject).order(:position) }
   end
 end

--- a/app/models/questionable/subject.rb
+++ b/app/models/questionable/subject.rb
@@ -1,0 +1,11 @@
+module Questionable
+  # A subject is used to group assignments into similar concepts
+  # e.g. math questions can be grouped by a Mathematics subject.
+  class Subject < ApplicationRecord
+    has_many :assignments, inverse_of: :subject, as: :subject, dependent: :nullify
+    has_many :questions, through: :assignments
+
+    validates :slug, presence: true, uniqueness: true
+    validates :title, presence: true
+  end
+end

--- a/db/migrate/20190903161741_create_questionable_subjects.rb
+++ b/db/migrate/20190903161741_create_questionable_subjects.rb
@@ -1,0 +1,11 @@
+class CreateQuestionableSubjects < ActiveRecord::Migration[5.0]
+  def change
+    create_table :questionable_subjects do |t|
+      t.string :slug, null: false
+      t.string :title, null: false
+      t.timestamps
+    end
+
+    add_index :questionable_subjects, :slug, unique: true
+  end
+end

--- a/lib/questionable/version.rb
+++ b/lib/questionable/version.rb
@@ -1,3 +1,3 @@
 module Questionable
-  VERSION = '0.8.1'.freeze
+  VERSION = '0.9.0'.freeze
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017_01_27_203606) do
+ActiveRecord::Schema.define(version: 2019_09_03_161741) do
 
   create_table "questionable_answers", force: :cascade do |t|
     t.integer "user_id"
@@ -47,12 +47,20 @@ ActiveRecord::Schema.define(version: 2017_01_27_203606) do
   end
 
   create_table "questionable_questions", force: :cascade do |t|
-    t.string "category"
-    t.string "title"
-    t.string "note"
-    t.string "input_type"
+    t.string "category", limit: 255
+    t.string "title", limit: 255
+    t.string "note", limit: 255
+    t.string "input_type", limit: 255
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "questionable_subjects", force: :cascade do |t|
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_questionable_subjects_on_slug", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :subject, class: Questionable::Subject do
+    sequence(:slug) { |num| "subject-#{num}" }
+    sequence(:subject) { |num| "Subject #{num}" }
+  end
+end

--- a/spec/models/questionable/assignment_spec.rb
+++ b/spec/models/questionable/assignment_spec.rb
@@ -5,22 +5,12 @@ module Questionable
     describe '.with_subject' do
       subject { Assignment.with_subject(assignment_subject) }
 
-      context 'with a string' do
-        let(:assignment_subject) { 'foobar' }
-        let!(:assignment) { create(:assignment, subject_type: assignment_subject) }
-        it { is_expected.to eq [assignment] }
-      end
-
-      context 'with a symbol' do
-        let(:assignment_subject) { :foobar }
-        let!(:assignment) { create(:assignment, subject_type: assignment_subject) }
-        it { is_expected.to eq [assignment] }
-      end
-
-      context 'with an object' do
-        let(:assignment_subject) { create(:user) }
-        let!(:assignment) { create(:assignment, subject: assignment_subject) }
-        it { is_expected.to eq [assignment] }
+      [:subject, :user].each do |factory|
+        context "with #{factory}" do
+          let(:assignment_subject) { create(factory) }
+          let!(:assignment) { create(:assignment, subject: assignment_subject) }
+          it { is_expected.to eq [assignment] }
+        end
       end
     end
   end

--- a/spec/models/questionable/question_spec.rb
+++ b/spec/models/questionable/question_spec.rb
@@ -7,22 +7,12 @@ module Questionable
     describe '.with_subject' do
       subject { Question.with_subject(assignment_subject) }
 
-      context 'with a string' do
-        let(:assignment_subject) { 'foobar' }
-        let!(:assignment) { create(:assignment, question: question, subject_type: assignment_subject) }
-        it { is_expected.to eq [question] }
-      end
-
-      context 'with a symbol' do
-        let(:assignment_subject) { :foobar }
-        let!(:assignment) { create(:assignment, question: question, subject_type: assignment_subject) }
-        it { is_expected.to eq [question] }
-      end
-
-      context 'with an object' do
-        let(:assignment_subject) { create(:user) }
-        let!(:assignment) { create(:assignment, question: question, subject: assignment_subject) }
-        it { is_expected.to eq [question] }
+      [:subject, :user].each do |factory|
+        context "with #{factory}" do
+          let(:assignment_subject) { create(factory) }
+          let!(:assignment) { create(:assignment, question: question, subject: assignment_subject) }
+          it { is_expected.to eq [question] }
+        end
       end
     end
 

--- a/spec/models/questionable/subject_spec.rb
+++ b/spec/models/questionable/subject_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+module Questionable
+  describe Subject do
+    let(:assignment_subject) { create(:subject) }
+
+    describe '#assignments' do
+      subject { assignment_subject.assignments }
+      let!(:assignment) { create(:assignment, subject: assignment_subject) }
+      it { is_expected.to include assignment }
+    end
+
+    describe '#questions' do
+      subject { assignment_subject.questions }
+      let!(:assignment) { create(:assignment, subject: assignment_subject) }
+      it { is_expected.to include assignment.question }
+    end
+  end
+end


### PR DESCRIPTION
* This is necessary in order to eagerload the subject from the assignment
* Updating to version 0.9.0